### PR TITLE
Update runtime for GNOME 44

### DIFF
--- a/org.emilien.SpaceLaunch.json
+++ b/org.emilien.SpaceLaunch.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.emilien.SpaceLaunch",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "spacelaunch",
     "finish-args" : [


### PR DESCRIPTION
Update runtime for GNOME 44 because GNOME 43 runtime is no longer supported as of September 20, 2023